### PR TITLE
Add C/C++ routine for `shmem_wait_until`: long

### DIFF
--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -11,6 +11,7 @@ where \TYPE{} is one of the point-to-point synchronization types specified by
 Table \ref{p2psynctypes}.
 
 \begin{Csynopsis}
+void shmem_wait_until(long *ivar, shmem_cmp_t cmp, long cmp_value);
 void shmem_<TYPENAME>_wait_until(TYPE *ivar, shmem_cmp_t cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the point-to-point synchronization types and has a


### PR DESCRIPTION
Not yet deprecated. Related #176. Closes #184.