### PR TITLE
Fix issues with shmem_cmp_t

### DIFF
--- a/content/p2p_sync_intro.tex
+++ b/content/p2p_sync_intro.tex
@@ -43,10 +43,10 @@ does not provide exact-width integer types with \HEADER{stdint.h}, an
   \end{center}
 \end{table}
 
-The point-to-point synchronization interface provides the enumerated type
-\CTYPE{shmem\_cmp\_t}, whose enumerators specify the comparison operators used
-by synchronization routines that take a \CTYPE{shmem\_cmp\_t} argument. The
-enumerators of \CTYPE{shmem\_cmp\_t} and their associated operations are
+The point-to-point synchronization interface provides named constants whose
+values are integer constant expressions that specify the comparison operation
+used by \openshmem synchronization routines.
+The constant names and associated operations are
 presented in Table~\ref{p2p-consts}.  For Fortran, the constant names of
 Table~\ref{p2p-consts} shall be identifiers for integer parameters of
 default kind corresponding to the associated comparison operation.
@@ -63,7 +63,7 @@ default kind corresponding to the associated comparison operation.
       SHMEM\_CMP\_LT   & Less than                \\
       SHMEM\_CMP\_LE   & Less than or equal to    \\ \hline
     \end{tabular}
-    \caption{Point-to-Point Comparison Enumeration Constants}
+    \caption{Point-to-Point Comparison Constants}
     \label{p2p-consts}
   \end{center}
 \end{table}

--- a/content/shmem_test.tex
+++ b/content/shmem_test.tex
@@ -5,13 +5,13 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-int shmem_test(TYPE *ivar, shmem_cmp_t cmp, TYPE cmp_value);
+int shmem_test(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the point-to-point synchronization types specified by
 Table \ref{p2psynctypes}.
 
 \begin{Csynopsis}
-int shmem_<TYPENAME>_test(TYPE *ivar, shmem_cmp_t cmp, TYPE cmp_value);
+int shmem_<TYPENAME>_test(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the point-to-point synchronization types and has a
 corresponding \TYPENAME{} specified by Table \ref{p2psynctypes}.

--- a/content/shmem_wait.tex
+++ b/content/shmem_wait.tex
@@ -5,14 +5,14 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-void shmem_wait_until(TYPE *ivar, shmem_cmp_t cmp, TYPE cmp_value);
+void shmem_wait_until(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{C11synopsis}
 where \TYPE{} is one of the point-to-point synchronization types specified by
 Table \ref{p2psynctypes}.
 
 \begin{Csynopsis}
-void shmem_wait_until(long *ivar, shmem_cmp_t cmp, long cmp_value);
-void shmem_<TYPENAME>_wait_until(TYPE *ivar, shmem_cmp_t cmp, TYPE cmp_value);
+void shmem_wait_until(long *ivar, int cmp, long cmp_value);
+void shmem_<TYPENAME>_wait_until(TYPE *ivar, int cmp, TYPE cmp_value);
 \end{Csynopsis}
 where \TYPE{} is one of the point-to-point synchronization types and has a
 corresponding \TYPENAME{} specified by Table~\ref{p2psynctypes}.
@@ -42,7 +42,7 @@ CALL SHMEM_WAIT_UNTIL(ivar, cmp, cmp_value)
     the type of \VAR{ivar} should match that implied in the SYNOPSIS section.} 
 \apiargument{IN}{cmp}{The compare operator that compares \VAR{ivar} with
   \VAR{cmp\_value}.  When using \Fortran, it must  be of default kind.
-  When using \CorCpp, it must be of type \CTYPE{shmem\_cmp\_t}.}
+  When using \CorCpp, it must be of type \CTYPE{int}.}
 \apiargument{IN}{cmp\_value}{\VAR{cmp\_value} must be of type integer.  When
     using \CorCpp, the type of \VAR{cmp\_value} should match that implied in the
     SYNOPSIS section.  When using \Fortran, cmp\_value must be an integer of

--- a/example_code/shmem_test_example1.c
+++ b/example_code/shmem_test_example1.c
@@ -1,7 +1,7 @@
 #include <stdio.h>
 #include <shmem.h>
 
-int user_wait_any(long *ivar, int count, shmem_cmp_t cmp, long value)
+int user_wait_any(long *ivar, int count, int cmp, long value)
 {
   int idx = 0;
   while (!shmem_test(&ivar[idx], cmp, value))

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -367,13 +367,13 @@ minus .2ex}{-1em}{\normalsize\sf}}
 { 
   \textbf{C11:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn},
+    morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_ctx_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
 { 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 
@@ -381,7 +381,7 @@ minus .2ex}{-1em}{\normalsize\sf}}
 { 
   \textbf{C/C++:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE},
+    morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}
@@ -389,9 +389,10 @@ minus .2ex}{-1em}{\normalsize\sf}}
   \textbf{C/C++:} 
   \color{red}  
   {\lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t}, aboveskip=0pt, belowskip=0pt}}
-  }
-  {}
+      morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_ctx_t},
+      aboveskip=0pt, belowskip=0pt}}
+}
+{}
   
 \lstnewenvironment{Fsynopsis}
 { \deprecationstart \\

--- a/utils/defs.tex
+++ b/utils/defs.tex
@@ -243,8 +243,7 @@ minus .2ex}{-1em}{\normalsize\sf}}
     shmem_short_fadd, shmem_int_fadd, shmem_long_fadd,
     shmem_set_lock, shmem_test_lock, shmem_clear_lock,
     shmem_long_sum_to_all,
-    shmem_complexd_sum_to_all,
-    shmem_cmp_t
+    shmem_complexd_sum_to_all
   },
   keywordstyle=\color{black}\textbf,
   classoffset=0,
@@ -368,13 +367,13 @@ minus .2ex}{-1em}{\normalsize\sf}}
 { 
   \textbf{C11:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn, shmem_cmp_t},
+  morekeywords={size_t, ptrdiff_t, TYPE, _Noreturn},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisCol}
 { 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_cmp_t},
+  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE},
   aboveskip=0pt, belowskip=0pt}}{}
 
 
@@ -382,7 +381,7 @@ minus .2ex}{-1em}{\normalsize\sf}}
 { 
   \textbf{C/C++:} 
   \lstset{language={C}, backgroundcolor=\color{gray}, lineskip=2pt,
-  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE, shmem_cmp_t},
+  morekeywords={size_t, ptrdiff_t, TYPE, TYPENAME, SIZE},
   aboveskip=0pt, belowskip=0pt}}{}
 
 \lstnewenvironment{CsynopsisST}
@@ -471,7 +470,7 @@ minus .2ex}{-1em}{\normalsize\sf}}
     ##1
     \lstinputlisting[language={C}, tabsize=2,
       basicstyle=\ttfamily\footnotesize,
-      morekeywords={size_t, ptrdiff_t, shmem_cmp_t, shmem_ctx_t}]{##2}
+      morekeywords={size_t, ptrdiff_t, shmem_ctx_t}]{##2}
     ##3 }
 \newcommand{\apifexample}[3]{
     ##1


### PR DESCRIPTION
This commit addresses https://github.com/openshmem-org/specification/issues/175 by removing the enumerated type `shmem_cmp_t` in favor of `int`-typed arguments to `shmem_{wait, wait_until, test}`.

Review requested by @jamesaross

Poking @spotluri 